### PR TITLE
Add alternative operator for null results in jq filter

### DIFF
--- a/to-rdjson.jq
+++ b/to-rdjson.jq
@@ -5,7 +5,7 @@
     name: "tfsec",
     url: "https://github.com/aquasecurity/tfsec"
   },
-  diagnostics: .results | map({
+  diagnostics: (.results // {}) | map({
     message: .description,
     code: {
       value: .rule_id,


### PR DESCRIPTION
See https://github.com/reviewdog/action-tfsec/pull/26#issuecomment-964539205

When `tfsec` finds no warnings or errors, it returns a result like:
```
{
  "results": null
}
```

The recent addition of a `jq` filter breaks when it receives this input, as it expects to `map` over the results. This change uses the alternative operator to pass in an empty set instead of a null value, so that we can get an acceptable default.

## Testing
I tested on two (private 😞) terraform repos: one with `tfsec` results and one without.
- On the repo with results, `$ tfsec --format=json . | jq -r -f <your_path>/to-rdjson.jq` returned equivalent output, as expected.
- On the repo with no results:
    - Before this change:
     ```
    $ tfsec --format=json . | jq -r -f <your_path>/to-rdjson.jq
    jq: error (at <stdin>:3): Cannot iterate over null (null)
    ```

    - After this change:
    ```
    $ tfsec --format=json . | jq -r -f <your_path>/to-rdjson.jq
    {
      "source": {
        "name": "tfsec",
        "url": "https://github.com/aquasecurity/tfsec"
      },
      "diagnostics": []
    }
    ```