### PR TITLE
update GITHUB_OUTPUT instead of using set-output

### DIFF
--- a/script.sh
+++ b/script.sh
@@ -80,8 +80,8 @@ echo '::group:: Running tfsec with reviewdog 🐶 ...'
         ${INPUT_FLAGS}
 
   tfsec_return="${PIPESTATUS[0]}" reviewdog_return="${PIPESTATUS[2]}" exit_code=$?
-  echo "::set-output name=tfsec-return-code::${tfsec_return}"
-  echo "::set-output name=reviewdog-return-code::${reviewdog_return}"
+  echo "tfsec-return-code=${tfsec_return}" >> $GITHUB_OUTPUT
+  echo "reviewdog-return-code=${reviewdog_return}" >> $GITHUB_OUTPUT
 echo '::endgroup::'
 
 exit "${exit_code}"

--- a/script.sh
+++ b/script.sh
@@ -80,8 +80,8 @@ echo '::group:: Running tfsec with reviewdog 🐶 ...'
         ${INPUT_FLAGS}
 
   tfsec_return="${PIPESTATUS[0]}" reviewdog_return="${PIPESTATUS[2]}" exit_code=$?
-  echo "tfsec-return-code=${tfsec_return}" >> $GITHUB_OUTPUT
-  echo "reviewdog-return-code=${reviewdog_return}" >> $GITHUB_OUTPUT
+  echo "tfsec-return-code=${tfsec_return}" >> "$GITHUB_OUTPUT"
+  echo "reviewdog-return-code=${reviewdog_return}" >> "$GITHUB_OUTPUT"
 echo '::endgroup::'
 
 exit "${exit_code}"


### PR DESCRIPTION
This patch modify to update `$GITHUB_OUTPUT`  instead of using `set-output` command because set-output command is deprecated.

see: https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/