### PR TITLE
Adding a `name` input to allow user to name the report

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,9 +44,9 @@ Optional. Report level for reviewdog [`info`,`warning`,`error`].
 It's same as `-level` flag of reviewdog.
 The default is `error`.
 
-### `name`
+### `tool_name`
 
-Optional. Name of the report as to how it will show up in the GitHub UI.
+Optional. Name of the tool being used. This controls how it will show up in the GitHub UI.
 The default is `tfsec`.
 
 ### `reporter`

--- a/README.md
+++ b/README.md
@@ -44,6 +44,11 @@ Optional. Report level for reviewdog [`info`,`warning`,`error`].
 It's same as `-level` flag of reviewdog.
 The default is `error`.
 
+### `name`
+
+Optional. Name of the report as to how it will show up in the GitHub UI.
+The default is `tfsec`.
+
 ### `reporter`
 
 Optional. Reporter of reviewdog command [`github-pr-check`,`github-pr-review`].

--- a/action.yml
+++ b/action.yml
@@ -17,6 +17,12 @@ inputs:
     description: 'Report level for reviewdog [info,warning,error]'
     default: 'error'
     required: false
+  tool_name:
+    description: |
+      The name of the tool being used. This name is used for the report name.
+      Default is tfsec.
+    default: 'tfsec'
+    required: false
   reporter:
     description: |
       Reporter of reviewdog command [github-pr-check,github-pr-review].

--- a/action.yml
+++ b/action.yml
@@ -17,7 +17,7 @@ inputs:
     description: 'Report level for reviewdog [info,warning,error]'
     default: 'error'
     required: false
-  name:
+  tool_name:
     description: |
       The name for the report as it will show up in GitHub's interface.
       Default is tfsec.
@@ -83,7 +83,7 @@ runs:
         INPUT_WORKING_DIRECTORY: ${{ inputs.working_directory }}
         INPUT_LEVEL: ${{ inputs.level }}
         INPUT_REPORTER: ${{ inputs.reporter }}
-        INPUT_NAME: ${{ inputs.name }}
+        INPUT_TOOL_NAME: ${{ inputs.tool_name }}
         INPUT_FILTER_MODE: ${{ inputs.filter_mode }}
         INPUT_FAIL_ON_ERROR: ${{ inputs.fail_on_error }}
         INPUT_FLAGS: ${{ inputs.flags }}

--- a/action.yml
+++ b/action.yml
@@ -17,9 +17,9 @@ inputs:
     description: 'Report level for reviewdog [info,warning,error]'
     default: 'error'
     required: false
-  tool_name:
+  name:
     description: |
-      The name of the tool being used. This name is used for the report name.
+      The name for the report as it will show up in GitHub's interface.
       Default is tfsec.
     default: 'tfsec'
     required: false
@@ -83,7 +83,7 @@ runs:
         INPUT_WORKING_DIRECTORY: ${{ inputs.working_directory }}
         INPUT_LEVEL: ${{ inputs.level }}
         INPUT_REPORTER: ${{ inputs.reporter }}
-        INPUT_TOOL_NAME: ${{ inputs.tool_name }}
+        INPUT_NAME: ${{ inputs.name }}
         INPUT_FILTER_MODE: ${{ inputs.filter_mode }}
         INPUT_FAIL_ON_ERROR: ${{ inputs.fail_on_error }}
         INPUT_FLAGS: ${{ inputs.flags }}

--- a/action.yml
+++ b/action.yml
@@ -83,6 +83,7 @@ runs:
         INPUT_WORKING_DIRECTORY: ${{ inputs.working_directory }}
         INPUT_LEVEL: ${{ inputs.level }}
         INPUT_REPORTER: ${{ inputs.reporter }}
+        INPUT_TOOL_NAME: ${{ inputs.tool_name }}
         INPUT_FILTER_MODE: ${{ inputs.filter_mode }}
         INPUT_FAIL_ON_ERROR: ${{ inputs.fail_on_error }}
         INPUT_FLAGS: ${{ inputs.flags }}

--- a/script.sh
+++ b/script.sh
@@ -72,7 +72,7 @@ echo '::group:: Running tfsec with reviewdog 🐶 ...'
   "${TFSEC_PATH}/tfsec" --format=json ${INPUT_TFSEC_FLAGS:-} . \
     | jq -r -f "${GITHUB_ACTION_PATH}/to-rdjson.jq" \
     |  "${REVIEWDOG_PATH}/reviewdog" -f=rdjson \
-        -name="${INPUT_TOOL_NAME}" \
+        -name="${INPUT_NAME}" \
         -reporter="${INPUT_REPORTER}" \
         -level="${INPUT_LEVEL}" \
         -fail-on-error="${INPUT_FAIL_ON_ERROR}" \

--- a/script.sh
+++ b/script.sh
@@ -72,7 +72,7 @@ echo '::group:: Running tfsec with reviewdog 🐶 ...'
   "${TFSEC_PATH}/tfsec" --format=json ${INPUT_TFSEC_FLAGS:-} . \
     | jq -r -f "${GITHUB_ACTION_PATH}/to-rdjson.jq" \
     |  "${REVIEWDOG_PATH}/reviewdog" -f=rdjson \
-        -name="${INPUT_NAME}" \
+        -name="${INPUT_TOOL_NAME}" \
         -reporter="${INPUT_REPORTER}" \
         -level="${INPUT_LEVEL}" \
         -fail-on-error="${INPUT_FAIL_ON_ERROR}" \

--- a/script.sh
+++ b/script.sh
@@ -72,7 +72,7 @@ echo '::group:: Running tfsec with reviewdog 🐶 ...'
   "${TFSEC_PATH}/tfsec" --format=json ${INPUT_TFSEC_FLAGS:-} . \
     | jq -r -f "${GITHUB_ACTION_PATH}/to-rdjson.jq" \
     |  "${REVIEWDOG_PATH}/reviewdog" -f=rdjson \
-        -name="tfsec" \
+        -name="${INPUT_TOOL_NAME}" \
         -reporter="${INPUT_REPORTER}" \
         -level="${INPUT_LEVEL}" \
         -fail-on-error="${INPUT_FAIL_ON_ERROR}" \


### PR DESCRIPTION
Allowing users to specify the name of the report as to how it should show up in the GitHub UI