### PR TITLE
Tentatively fix the version of tfsec at v1.28.1

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -43,7 +43,7 @@ inputs:
     description: |
       The version of tfsec to install.
       Default is latest.
-    default: 'latest'
+    default: 'v1.28.1'
     required: false
   tfsec_flags:
     description: |


### PR DESCRIPTION
The GitHub Actions doesn't work with the latest version tfsec v1.28.2. So, it would be good to tentatively fix the tfsec version with `v1.28.1` right now, as it may take a bit time to identify the root cause of breaking changes on the tfsec side.