### PR TITLE
Fix Banner Removal and tfsec Severity Mapping

### DIFF
--- a/script.sh
+++ b/script.sh
@@ -71,12 +71,7 @@ echo '::group:: Running tfsec with reviewdog 🐶 ...'
   set +Eeuo pipefail
 
   # shellcheck disable=SC2086
-  "${TFSEC_PATH}/tfsec" --format=json ${INPUT_TFSEC_FLAGS:-} . \
-    | {
-      # workaround for #95
-      # remove "tfsec is joining the Trivy family" banner
-      perl -E 'undef $/; my $txt = <>; $txt =~ s/^[^{]*//m; print $txt'
-    } \
+  "${TFSEC_PATH}/tfsec" --format=json ${INPUT_TFSEC_FLAGS:-} . 2> /dev/null \
     | jq -r -f "${GITHUB_ACTION_PATH}/to-rdjson.jq" \
     |  "${REVIEWDOG_PATH}/reviewdog" -f=rdjson \
         -name="${INPUT_TOOL_NAME}" \
@@ -86,7 +81,7 @@ echo '::group:: Running tfsec with reviewdog 🐶 ...'
         -filter-mode="${INPUT_FILTER_MODE}" \
         ${INPUT_FLAGS}
 
-  tfsec_return="${PIPESTATUS[0]}" reviewdog_return="${PIPESTATUS[3]}" exit_code=$?
+  tfsec_return="${PIPESTATUS[0]}" reviewdog_return="${PIPESTATUS[2]}" exit_code=$?
   echo "tfsec-return-code=${tfsec_return}" >> "$GITHUB_OUTPUT"
   echo "reviewdog-return-code=${reviewdog_return}" >> "$GITHUB_OUTPUT"
 echo '::endgroup::'

--- a/to-rdjson.jq
+++ b/to-rdjson.jq
@@ -19,7 +19,7 @@
         },
       }
     },
-    severity: (if .severity | startswith("HIGH") then
+    severity: (if .severity | startswith("CRITICAL") then
               "ERROR"
             elif .severity | startswith("MEDIUM") then
               "WARNING"


### PR DESCRIPTION
This pull request addresses two specific issues to improve the existing functionality:

Banner Removal: Initially, the workaround implemented for removing the banner was not functioning as expected. We've made adjustments to properly discard the banner from STDERR.

Severity Mapping for tfsec: Previously, CRITICAL issues identified by tfsec were being passed to reviewdog as null. This issue has been corrected.

These fixes enhance the tool's usability and reliability for Github Actions etc.
