### PR TITLE
Fix tfsec severity mapping (again)

### DIFF
--- a/to-rdjson.jq
+++ b/to-rdjson.jq
@@ -21,6 +21,8 @@
     },
     severity: (if .severity | startswith("CRITICAL") then
               "ERROR"
+            elif .severity | startswith("HIGH") then
+              "ERROR"              
             elif .severity | startswith("MEDIUM") then
               "WARNING"
             elif .severity | startswith("LOW") then


### PR DESCRIPTION
This pull request modifies the Severity Mapping.

tfsec returns 4 types, but reviewdog only has 3 types.

The CRITICAL and HIGH from tfsec are mapped to ERROR in reviewdog.

In the fix for #110, HIGH was not handled.