### PR TITLE
CI tfsec: Temporarily exclude windows-latest from runs-on

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -130,7 +130,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        platform: [ubuntu-latest, macos-latest, windows-latest]
+        platform: [ubuntu-latest, macos-latest]
     name: tfsec (${{ matrix.platform }})
     runs-on: ${{ matrix.platform }}
 


### PR DESCRIPTION
CI `tfsec (windows-latest)` fails due to https://github.com/actions/runner-images/issues/10009.
Therefore, I temporarily exclude `windows-latest` from `runs-on` of CI `tfsec` until it is resolved.